### PR TITLE
Sum query losses instead of recording the last

### DIFF
--- a/maml.py
+++ b/maml.py
@@ -103,7 +103,7 @@ class maml(nn.Module):
                 loss = 0
                 for i in range(num_batch):
                     pred_query_y = self(x_spt[i], y_spt[i], x_qry[i])
-                    loss = self.loss(pred_query_y, y_qry[i])
+                    loss += self.loss(pred_query_y, y_qry[i])
                 loss /= num_batch
                 self.meta_optim.zero_grad()
                 loss.backward()


### PR DESCRIPTION
Hello,

I tried to do this via Issues, but I couldn't. Maybe that option is disabled on this repo? The issue is the following:

I'm trying to understand how MAML works with this code. It is very clear and well documented :+1: :+1: . However, I have a question on the line that I change on this PR.

Why the line 106 is using `=` instead of `+=`? It makes more sense to me that the losses must be sumed, but maybe I'm wrong. What is the correct version and why?

Thanks in advance.